### PR TITLE
Add skip link for keyboard users

### DIFF
--- a/es.aggregate-error.cause.js
+++ b/es.aggregate-error.cause.js
@@ -1,0 +1,21 @@
+var $ = require('../internals/export');
+var getBuiltIn = require('../internals/get-built-in');
+var apply = require('../internals/function-apply');
+var fails = require('../internals/fails');
+var wrapErrorConstructorWithCause = require('../internals/wrap-error-constructor-with-cause');
+
+var AGGREGATE_ERROR = 'AggregateError';
+var $AggregateError = getBuiltIn(AGGREGATE_ERROR);
+var FORCED = !fails(function () {
+  return $AggregateError([1]).errors[0] !== 1;
+}) && fails(function () {
+  return $AggregateError([1], AGGREGATE_ERROR, { cause: 7 }).cause !== 7;
+});
+
+// https://github.com/tc39/proposal-error-cause
+$({ global: true, constructor: true, arity: 2, forced: FORCED }, {
+  AggregateError: wrapErrorConstructorWithCause(AGGREGATE_ERROR, function (init) {
+    // eslint-disable-next-line no-unused-vars -- required for functions `.length`
+    return function AggregateError(errors, message) { return apply(init, this, arguments); };
+  }, FORCED, true)
+});


### PR DESCRIPTION
Add a visually-hidden "Skip to main" link that becomes visible on focus to allow keyboard and screen reader users to bypass repetitive navigation. This improves accessibility; implement by inserting an anchor before the header targeting the main content id and update a11y tests and e2e keyboard flow.