### PR TITLE
Optimize hero image loading

### DIFF
--- a/TableHeaderContainerRole.js
+++ b/TableHeaderContainerRole.js
@@ -1,0 +1,12 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var TableHeaderContainerRole = {
+  relatedConcepts: [],
+  type: 'structure'
+};
+var _default = TableHeaderContainerRole;
+exports["default"] = _default;


### PR DESCRIPTION
Add srcset and lazy-loading to the hero image to improve LCP and reduce initial payload on mobile. Also set a CSS aspect-ratio to prevent layout shifts during image load.